### PR TITLE
Add horizontal scroll virtualization

### DIFF
--- a/media/editor/dataDisplay.css
+++ b/media/editor/dataDisplay.css
@@ -93,9 +93,11 @@
 }
 
 .data-display {
-	position: sticky;
-	inset: 0;
-	height: 0px;
+        position: sticky;
+        inset: 0;
+        height: 0px;
+        overflow-x: auto;
+        overflow-y: hidden;
 }
 
 .data-inspector-wrap {

--- a/media/editor/dataDisplay.css
+++ b/media/editor/dataDisplay.css
@@ -93,11 +93,9 @@
 }
 
 .data-display {
-        position: sticky;
-        inset: 0;
-        height: 0px;
-        overflow-x: auto;
-        overflow-y: hidden;
+	position: sticky;
+	inset: 0;
+	height: 0px;
 }
 
 .data-inspector-wrap {

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license
 
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRecoilValue, useSetRecoilState, useRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { HexDecorator } from "../../shared/decorators";
 import { EditRangeOp, HexDocumentEditOp } from "../../shared/hexDocumentModel";
 import {
@@ -120,9 +120,6 @@ export const DataDisplay: React.FC = () => {
 	const setOffset = useSetRecoilState(select.offset);
 	const setScrollBounds = useSetRecoilState(select.scrollBounds);
 	const columnWidth = useRecoilValue(select.columnWidth);
-	const showDecodedText = useRecoilValue(select.showDecodedText);
-	const [columnOffset, setColumnOffset] = useRecoilState(select.columnOffset);
-	const visibleColumns = useRecoilValue(select.visibleColumns);
 	const dimensions = useRecoilValue(select.dimensions);
 	const fileSize = useRecoilValue(select.fileSize);
 	const copyType = useRecoilValue(select.copyType);
@@ -140,33 +137,6 @@ export const DataDisplay: React.FC = () => {
 		window.addEventListener("mouseup", l, { passive: true });
 		return () => window.removeEventListener("mouseup", l);
 	}, []);
-
-	useEffect(() => {
-		const el = containerRef.current;
-		if (!el) {
-			return;
-		}
-		const colPx = dimensions.rowPxHeight * (showDecodedText ? 1 + textCellWidth : 1);
-		const onScroll = () => {
-			const newOffset = Math.floor(el.scrollLeft / colPx);
-			const maxOffset = Math.max(0, columnWidth - visibleColumns);
-			setColumnOffset(Math.max(0, Math.min(newOffset, maxOffset)));
-		};
-		el.addEventListener("scroll", onScroll);
-		return () => el.removeEventListener("scroll", onScroll);
-	}, [dimensions, columnWidth, visibleColumns, showDecodedText]);
-
-	useEffect(() => {
-		const el = containerRef.current;
-		if (!el) {
-			return;
-		}
-		const colPx = dimensions.rowPxHeight * (showDecodedText ? 1 + textCellWidth : 1);
-		const desired = columnOffset * colPx;
-		if (Math.abs(el.scrollLeft - desired) > 1) {
-			el.scrollLeft = desired;
-		}
-	}, [columnOffset, dimensions, showDecodedText]);
 
 	// When the focused byte changes, make sure it's in view
 	useEffect(() => {

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license
 
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState, useRecoilState } from "recoil";
 import { HexDecorator } from "../../shared/decorators";
 import { EditRangeOp, HexDocumentEditOp } from "../../shared/hexDocumentModel";
 import {
@@ -68,6 +68,8 @@ const Address: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...
 
 export const DataHeader: React.FC = () => {
 	const editorSettings = useRecoilValue(select.editorSettings);
+	const visibleColumns = useRecoilValue(select.visibleColumns);
+	const columnOffset = useRecoilValue(select.columnOffset);
 	const inspectorLocation = useRecoilValue(select.dataInspectorLocation);
 
 	return (
@@ -76,8 +78,8 @@ export const DataHeader: React.FC = () => {
 				<Address>00000000</Address>
 			</DataCellGroup>
 			<DataCellGroup>
-				{new Array(editorSettings.columnWidth).fill(0).map((_v, i) => (
-					<Byte key={i} value={i & 0xff} />
+				{new Array(visibleColumns).fill(0).map((_v, i) => (
+					<Byte key={i} value={(i + columnOffset) & 0xff} />
 				))}
 			</DataCellGroup>
 			{editorSettings.showDecodedText && (
@@ -85,7 +87,7 @@ export const DataHeader: React.FC = () => {
 				// Flex-shrink prevents the data inspector overlapping on narrow screens
 				<DataCellGroup
 					style={{
-						width: `calc(var(--cell-size) * ${editorSettings.columnWidth * textCellWidth})`,
+						width: `calc(var(--cell-size) * ${visibleColumns * textCellWidth})`,
 						flexShrink: 0,
 					}}
 				>
@@ -118,6 +120,9 @@ export const DataDisplay: React.FC = () => {
 	const setOffset = useSetRecoilState(select.offset);
 	const setScrollBounds = useSetRecoilState(select.scrollBounds);
 	const columnWidth = useRecoilValue(select.columnWidth);
+	const showDecodedText = useRecoilValue(select.showDecodedText);
+	const [columnOffset, setColumnOffset] = useRecoilState(select.columnOffset);
+	const visibleColumns = useRecoilValue(select.visibleColumns);
 	const dimensions = useRecoilValue(select.dimensions);
 	const fileSize = useRecoilValue(select.fileSize);
 	const copyType = useRecoilValue(select.copyType);
@@ -135,6 +140,33 @@ export const DataDisplay: React.FC = () => {
 		window.addEventListener("mouseup", l, { passive: true });
 		return () => window.removeEventListener("mouseup", l);
 	}, []);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) {
+			return;
+		}
+		const colPx = dimensions.rowPxHeight * (showDecodedText ? 1 + textCellWidth : 1);
+		const onScroll = () => {
+			const newOffset = Math.floor(el.scrollLeft / colPx);
+			const maxOffset = Math.max(0, columnWidth - visibleColumns);
+			setColumnOffset(Math.max(0, Math.min(newOffset, maxOffset)));
+		};
+		el.addEventListener("scroll", onScroll);
+		return () => el.removeEventListener("scroll", onScroll);
+	}, [dimensions, columnWidth, visibleColumns, showDecodedText]);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) {
+			return;
+		}
+		const colPx = dimensions.rowPxHeight * (showDecodedText ? 1 + textCellWidth : 1);
+		const desired = columnOffset * colPx;
+		if (Math.abs(el.scrollLeft - desired) > 1) {
+			el.scrollLeft = desired;
+		}
+	}, [columnOffset, dimensions, showDecodedText]);
 
 	// When the focused byte changes, make sure it's in view
 	useEffect(() => {
@@ -329,7 +361,11 @@ const DataRows: React.FC = () => {
 
 	const rows: React.ReactChild[] = [];
 	// i === startPageStartsAt so that we always show at least 1 page, allowing users to append to empty files (#534)
-	for (let i = startPageStartsAt; i <= endPageStartsAt && (i === startPageStartsAt || i < fileSize); i += dataPageSize) {
+	for (
+		let i = startPageStartsAt;
+		i <= endPageStartsAt && (i === startPageStartsAt || i < fileSize);
+		i += dataPageSize
+	) {
 		rows.push(
 			<DataPage
 				key={i}
@@ -355,7 +391,9 @@ const LoadingDataRow: React.FC<{ width: number; showDecodedText: boolean }> = ({
 }) => {
 	const cells: React.ReactNode[] = [];
 	const text = strings.loadingUpper;
-	for (let i = 0; i < width; i++) {
+	const visibleColumns = useRecoilValue(select.visibleColumns);
+	const columnOffset = useRecoilValue(select.columnOffset);
+	for (let i = columnOffset; i < columnOffset + visibleColumns && i < width; i++) {
 		const str = (text[i * 2] || ".") + (text[i * 2 + 1] || ".");
 		cells.push(
 			<span className={dataCellCls} aria-hidden style={{ opacity: 0.5 }} key={i}>
@@ -703,12 +741,16 @@ const DataRowContents: React.FC<{
 		memoValue += "," + byte;
 	}
 
+	const visibleColumns = useRecoilValue(select.visibleColumns);
+	const columnOffset = useRecoilValue(select.columnOffset);
 	const { bytes, chars } = useMemo(() => {
 		const bytes: React.ReactChild[] = [];
 		const chars: React.ReactChild[] = [];
 		const searcher = binarySearch<HexDecorator>(d => d.range.end);
 		let j = searcher(offset, decorators);
-		for (let i = 0; i < width; i++) {
+		const start = columnOffset;
+		const end = Math.min(width, columnOffset + visibleColumns);
+		for (let i = start; i < end; i++) {
 			const boffset = offset + i;
 			const value = rawBytes[i];
 			let decorator: HexDecorator | undefined = undefined;

--- a/media/editor/hexEdit.tsx
+++ b/media/editor/hexEdit.tsx
@@ -18,6 +18,7 @@ import * as select from "./state";
 import { strings } from "./strings";
 import { throwOnUndefinedAccessInDev } from "./util";
 import { VsProgressIndicator } from "./vscodeUi";
+import { HorizontalScrollContainer } from "./horizontalScrollContainer";
 
 const style = throwOnUndefinedAccessInDev(_style);
 
@@ -76,8 +77,10 @@ const Editor: React.FC = () => {
 			>
 				<FindWidget />
 				<SettingsGear />
-				<DataHeader />
-				<ScrollContainer />
+				<HorizontalScrollContainer>
+					<DataHeader />
+					<ScrollContainer />
+				</HorizontalScrollContainer>
 				<ReadonlyWarning />
 				{inspectorLocation === InspectorLocation.Hover && <DataInspectorHover />}
 			</div>

--- a/media/editor/horizontalScrollContainer.css
+++ b/media/editor/horizontalScrollContainer.css
@@ -1,0 +1,9 @@
+.wrapper {
+    overflow-x: auto;
+    overflow-y: hidden;
+    flex-grow: 1;
+    flex-basis: 0;
+}
+.inner {
+    width: max-content;
+}

--- a/media/editor/horizontalScrollContainer.tsx
+++ b/media/editor/horizontalScrollContainer.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef } from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
+import _style from "./horizontalScrollContainer.css";
+import { throwOnUndefinedAccessInDev, clsx } from "./util";
+import * as select from "./state";
+
+const style = throwOnUndefinedAccessInDev(_style);
+
+const textCellWidth = 0.7;
+
+export const HorizontalScrollContainer: React.FC<{ className?: string }> = ({
+	children,
+	className,
+}) => {
+	const ref = useRef<HTMLDivElement | null>(null);
+	const [colOffset, setColOffset] = useRecoilState(select.columnOffset);
+	const columnWidth = useRecoilValue(select.columnWidth);
+	const visibleColumns = useRecoilValue(select.visibleColumns);
+	const showDecodedText = useRecoilValue(select.showDecodedText);
+	const dimensions = useRecoilValue(select.dimensions);
+
+	const colPx = dimensions.rowPxHeight * (1 + (showDecodedText ? textCellWidth : 0));
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const onScroll = () => {
+			const newOffset = Math.floor(el.scrollLeft / colPx);
+			const maxOffset = Math.max(0, columnWidth - visibleColumns);
+			setColOffset(Math.max(0, Math.min(newOffset, maxOffset)));
+		};
+		el.addEventListener("scroll", onScroll);
+		return () => el.removeEventListener("scroll", onScroll);
+	}, [colPx, columnWidth, visibleColumns]);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const desired = colOffset * colPx;
+		if (Math.abs(el.scrollLeft - desired) > 1) {
+			el.scrollLeft = desired;
+		}
+	}, [colOffset, colPx]);
+
+	return (
+		<div ref={ref} className={clsx(style.wrapper, className)}>
+			<div className={style.inner}>{children}</div>
+		</div>
+	);
+};

--- a/media/editor/horizontalScrollContainer.tsx
+++ b/media/editor/horizontalScrollContainer.tsx
@@ -42,9 +42,13 @@ export const HorizontalScrollContainer: React.FC<{ className?: string }> = ({
 		}
 	}, [colOffset, colPx]);
 
+	const width = columnWidth * colPx;
+
 	return (
 		<div ref={ref} className={clsx(style.wrapper, className)}>
-			<div className={style.inner}>{children}</div>
+			<div className={style.inner} style={{ width }}>
+				{children}
+			</div>
 		</div>
 	);
 };

--- a/media/editor/settings.tsx
+++ b/media/editor/settings.tsx
@@ -59,7 +59,7 @@ const ColumnWidth: React.FC = () => {
 	const updateColumnWidth = (evt: React.ChangeEvent<HTMLInputElement>) => {
 		updateSettings(s => {
 			const colWidth = isNaN(evt.target.valueAsNumber) ? 1 : Math.max(evt.target.valueAsNumber, 1);
-			const newSetting = { ...s, columnWidth: Math.min(colWidth, 32) };
+			const newSetting = { ...s, columnWidth: Math.min(colWidth, 512) };
 			return newSetting;
 		});
 	};
@@ -72,7 +72,7 @@ const ColumnWidth: React.FC = () => {
 				id="column-width"
 				value={settings.columnWidth}
 				min={1}
-				max={32}
+				max={512}
 				style={{ width: 40 }}
 				onChange={updateColumnWidth}
 			/>

--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -200,15 +200,9 @@ export const showDecodedText = selector({
 	get: ({ get }) => get(editorSettings).showDecodedText,
 });
 
-export const getDisplayedColumns = (d: IDimensions, showText: boolean): number => {
-	const perCol = d.rowPxHeight * (showText ? 1 + 0.7 : 1);
-	const usable = Math.max(0, d.width - d.rowPxHeight * 10);
-	return Math.max(1, Math.floor(usable / perCol));
-};
-
 export const visibleColumns = selector({
 	key: "visibleColumns",
-	get: ({ get }) => getDisplayedColumns(get(dimensions), get(showDecodedText)),
+	get: () => 64,
 });
 
 export const columnOffset = atom({

--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -200,6 +200,22 @@ export const showDecodedText = selector({
 	get: ({ get }) => get(editorSettings).showDecodedText,
 });
 
+export const getDisplayedColumns = (d: IDimensions, showText: boolean): number => {
+	const perCol = d.rowPxHeight * (showText ? 1 + 0.7 : 1);
+	const usable = Math.max(0, d.width - d.rowPxHeight * 10);
+	return Math.max(1, Math.floor(usable / perCol));
+};
+
+export const visibleColumns = selector({
+	key: "visibleColumns",
+	get: ({ get }) => getDisplayedColumns(get(dimensions), get(showDecodedText)),
+});
+
+export const columnOffset = atom({
+	key: "columnOffset",
+	default: 0,
+});
+
 // Atom used to invalidate data when a reload is requested.
 const reloadGeneration = atom({
 	key: "reloadGeneration",


### PR DESCRIPTION
## Summary
- introduce HorizontalScrollContainer for virtualized horizontal scrolling
- enable horizontal scrolling in data display with new container
- compute visible columns and offset in state
- update header and rows to render only visible data
- expand column width settings to a max of 512

## Testing
- `npm test` *(fails: Cannot find module 'chai' etc.)*
- `npm run fmt` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_684694005a9c832992fd4002844db7a0